### PR TITLE
feat: dropdown 컴포넌트 작업(default, 와인 구분)

### DIFF
--- a/src/app/test/HoyoungTest.tsx
+++ b/src/app/test/HoyoungTest.tsx
@@ -1,3 +1,57 @@
-export default function HoyoungTest() {
-  return <div className="text-gray-500">호영 테스트 페이지 준비 중...</div>;
+"use client";
+
+import Dropdown from "@/components/Dropdown/dropdown";
+
+export default function HoyeongTest() {
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      {/* ✅ md 사이즈 기본 드롭다운 */}
+      <div className="flex flex-col gap-2">
+        <Dropdown 
+          size="md" 
+          items={[
+            { label: "마이페이지", href: "/mypage"},
+            { label: "로그아웃", href: "/"},
+          ]}
+        />
+      </div>
+
+      {/* ✅ sm 사이즈 기본 드롭다운 */}
+      <div className="flex flex-col gap-2">
+        <Dropdown 
+          size="sm" 
+          items={[
+            { label: "마이페이지", href: "/mypage"},
+            { label: "로그아웃", href: "/"},
+          ]}
+        />
+      </div>
+
+      {/* ✅ md 사이즈 와인 선택 드롭다운 */}
+      <div className="flex flex-col gap-2">
+        <Dropdown
+          size="md"
+          items={[
+            { label: "Red" },
+            { label: "White" },
+            { label: "Sparkling" },
+          ]}
+          isWineDropdown={true}
+        />
+      </div>
+
+      {/* ✅ sm 사이즈 와인 선택 드롭다운 */}
+      <div className="flex flex-col gap-2">
+      <Dropdown
+          size="sm"
+          items={[
+            { label: "Red" },
+            { label: "White" },
+            { label: "Sparkling" },
+          ]}
+          isWineDropdown={true}
+        />
+      </div>
+    </div>
+  );
 }

--- a/src/components/Dropdown/dropdown.tsx
+++ b/src/components/Dropdown/dropdown.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from "react";
+import clsx from "clsx";
+
+/**
+ * ✅ 공통 드롭다운 컴포넌트
+ * - `size`: 드롭다운 서브메뉴 크기 지정 ("md" 또는 "sm")
+ * - `items`: 드롭다운 내부에 들어갈 메뉴 목록 (배열)
+ * - `className`: 추가적인 Tailwind 스타일 적용 가능
+ * - `isWineDropdown`: 텍스트 드롭다운이 아닌 와인 선택 드롭다운으로 전환
+ */
+
+interface DropdownProps {
+  size?: "md" | "sm";
+  className?: string;
+  items: { label: string; href?: string }[]; // 버튼 메뉴(텍스트) 동적 관리
+  isWineDropdown?: boolean;
+}
+
+export default function Dropdown({
+   size = "md", 
+   className, 
+   items, 
+   isWineDropdown = false, 
+}: DropdownProps) {
+
+  // 드롭다운 메뉴의 열림 상태를 관리하는 상태 변수
+  const [isOpen, setIsOpen] = useState(false);
+
+  // 드롭다운 컴포넌트의 DOM 참조 (외부 클릭 감지에 사용)
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // 드롭다운 열기/닫기 토글 함수
+  const toggleDropdown = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  // 드롭다운 외부 클릭 시 메뉴를 닫기 위한 효과
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () =>
+      document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // 드롭다운 메뉴 크기
+  const dropdownSizeStyles = {
+    md: isWineDropdown ? "w-[412px] h-auto" : "w-[126px] h-auto px-[1px] py-[3px]",
+    sm: isWineDropdown ? "w-[303px] h-auto" : "w-[101px] h-auto px-[1px]",
+  };
+
+  // 텍스트 스타일
+  // md: lg-16px-Medium
+  // sm: md-14px-Medium
+  // md-Winedropdown: lg-16px-medium
+  const textSizeStyles = {
+    md: isWineDropdown ? "text-[18px] font-medium" : "text-[16px] font-medium",
+    sm: isWineDropdown ? "text-[16px] font-medium" : "text-[14px] font-medium",
+  };
+
+  // 공통 버튼 스타일 (임의 설정)
+  const baseButtonStyles =
+    "flex items-center border border-[#CFDBEA] rounded-[16px] focus:outline-none transition-colors duration-200 px-4 py-2";
+
+  // 드롭다운 메뉴 스타일 (절대 위치로 오버레이되며, z-index로 기존 요소 위에 표시)
+  const dropdownMenuStyles =
+    "absolute mt-2 border border-[#CFDBEA] rounded-[16px] bg-white z-50 flex flex-col gap-0";
+
+  const dropdownItemStyles = clsx(
+    "flex justify-center items-center px-1 py-1 transition duration-200",
+    isWineDropdown ? "justify-start w-full" : "justify-center"
+  );
+
+  const dropdownHoverStyles = clsx(
+    "flex w-full py-[8px] hover:bg-purple-10 hover:text-purple-100 rounded-[8px]",
+    isWineDropdown ? "flex justify-center text-left px-6" : "flex justify-center text-center"
+  );
+
+  return (
+    <div className={clsx("relative inline-block", className)} ref={dropdownRef}>
+      {/* 드롭다운 트리거 버튼 */}
+      <button
+        onClick={toggleDropdown}
+        className={clsx(baseButtonStyles)}
+      >
+        {isWineDropdown ? "와인 선택" : "기본"}
+      </button>
+
+      {/* 드롭다운 메뉴 (isOpen이 true일 때 렌더링) */}
+      {isOpen && (
+        <div className={clsx(dropdownMenuStyles, dropdownSizeStyles[size])}>
+          {items.map((item, index) => (
+            <a
+              key={index}
+              href={item.href || "#"}
+              className={clsx(
+                dropdownItemStyles,
+                textSizeStyles[size],
+                index === 0 ? "rounded-t-[16px]" : "",
+                index === items.length - 1 ? "rounded-b-[16px]" : ""
+              )}
+            >
+              <div className={clsx(dropdownHoverStyles)}>{item.label}</div>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣ 이슈

- #18 

## 📝 작업 내용
- 공용 컴포넌트 : Dropdown 작업

## 📸 결과물
![image](https://github.com/user-attachments/assets/7b94a635-2e14-4baa-b4e2-914cfc13faa6)

![image](https://github.com/user-attachments/assets/625c6a5a-8114-4835-b9f3-5f662693253b)

![image](https://github.com/user-attachments/assets/c2ef9d78-d7fd-419a-b511-a97d4f9bcc39)

![image](https://github.com/user-attachments/assets/a9a6c923-714e-4eb9-8463-238497a653db)

![image](https://github.com/user-attachments/assets/08582fff-97db-4545-b5e9-1dcbe29b6e82)

## 👩‍💻 공유 포인트 및 논의 사항
- 와인 선택 Dropdown의 경우 내부 텍스트가 좌측 정렬이 되도록 수정 필요.
- Margin/Padding 등 크기 조절 부분에서 직관적인 수치를 사용하지 않아 추가 테스트 필요.