### PR TITLE
Feat: 모달/리뷰등록 Flavor컴포넌트 완료, FlavorSlider수정

### DIFF
--- a/src/components/Card/Flavor/FlavorSlider.tsx
+++ b/src/components/Card/Flavor/FlavorSlider.tsx
@@ -1,8 +1,26 @@
 "use client";
 
-import { useState } from "react";
+type FlavorSliderProps = {
+  lightBold: number;
+  setLightBold: (value: number) => void;
+  smoothTannic: number;
+  setSmoothTannic: (value: number) => void;
+  drySweet: number;
+  setDrySweet: (value: number) => void;
+  softAcidic: number;
+  setSoftAcidic: (value: number) => void;
+};
 
-const WineSliders = () => {
+export default function FlavorSlider({
+  lightBold,
+  setLightBold,
+  smoothTannic,
+  setSmoothTannic,
+  drySweet,
+  setDrySweet,
+  softAcidic,
+  setSoftAcidic,
+}: FlavorSliderProps) {
   const sliders = [
     { label: "바디감", leftLabel: "가벼워요", rightLabel: "진해요" },
     { label: "타닌", leftLabel: "부드러워요", rightLabel: "떫어요" },
@@ -10,12 +28,15 @@ const WineSliders = () => {
     { label: "산미", leftLabel: "안셔요", rightLabel: "많이셔요" },
   ];
 
-  const [values, setValues] = useState([50, 30, 40, 20]);
+  // props로 받은 상태값을 배열 형태로 정리 (순서 유지)
+  const values = [lightBold, smoothTannic, drySweet, softAcidic];
+
+  // 각 슬라이더의 setter 함수를 매핑
+  const setters = [setLightBold, setSmoothTannic, setDrySweet, setSoftAcidic];
 
   const handleChange = (index: number, value: number) => {
-    const newValues = [...values];
-    newValues[index] = value;
-    setValues(newValues);
+    // 해당하는 setter 함수 호출하여 상태 업데이트
+    setters[index](value);
   };
 
   return (
@@ -40,8 +61,7 @@ const WineSliders = () => {
               value={values[index]}
               onChange={(e) => handleChange(index, Number(e.target.value))}
               className="w-[260px] h-[6px] appearance-none bg-[#CFDBEA] rounded-full cursor-pointer 
-                         accent-[#6A42DB]
-"
+                         accent-[#6A42DB]"
             />
 
             <span className="text-[16px] font-medium text-[#2D3034]">
@@ -52,6 +72,4 @@ const WineSliders = () => {
       ))}
     </div>
   );
-};
-
-export default WineSliders;
+}

--- a/src/components/Modal/ModalReviewAdd/ModalReviewAdd.tsx
+++ b/src/components/Modal/ModalReviewAdd/ModalReviewAdd.tsx
@@ -34,7 +34,7 @@ export default function ModalReviewAdd({
 
   return (
     <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-50 ">
-      <div className="flex flex-col w-full max-w-[528px]  p-6 rounded-lg bg-white shadow-lg ">
+      <div className="flex flex-col gap-10 w-full max-w-[528px]  p-6 rounded-lg bg-white shadow-lg ">
         <ModalReviewHeader onClose={onClose} />
         <ModalReviewForm />
       </div>

--- a/src/components/Modal/ModalReviewAdd/components/ModalReviewFlavor.tsx
+++ b/src/components/Modal/ModalReviewAdd/components/ModalReviewFlavor.tsx
@@ -1,3 +1,39 @@
-export default function ModalReviewFlavor() {
-  return <div>맛</div>;
+import FlavorSlider from "@/components/Card/Flavor/FlavorSlider";
+
+type ModalReviewFlavorProps = {
+  lightBold: number;
+  setLightBold: (value: number) => void;
+  smoothTannic: number;
+  setSmoothTannic: (value: number) => void;
+  drySweet: number;
+  setDrySweet: (value: number) => void;
+  softAcidic: number;
+  setSoftAcidic: (value: number) => void;
+};
+
+export default function ModalReviewFlavor({
+  lightBold,
+  setLightBold,
+  smoothTannic,
+  setSmoothTannic,
+  drySweet,
+  setDrySweet,
+  softAcidic,
+  setSoftAcidic,
+}: ModalReviewFlavorProps) {
+  return (
+    <div>
+      <p className="xl-20px-bold">와인의 맛은 어땠나요?</p>
+      <FlavorSlider
+        lightBold={lightBold}
+        setLightBold={setLightBold}
+        smoothTannic={smoothTannic}
+        setSmoothTannic={setSmoothTannic}
+        drySweet={drySweet}
+        setDrySweet={setDrySweet}
+        softAcidic={softAcidic}
+        setSoftAcidic={setSoftAcidic}
+      />
+    </div>
+  );
 }

--- a/src/components/Modal/ModalReviewAdd/components/ModalReviewForm.tsx
+++ b/src/components/Modal/ModalReviewAdd/components/ModalReviewForm.tsx
@@ -5,20 +5,46 @@ import ModalReviewRate from "./ModalReviewRate";
 import ModalReviewSmell from "./ModalReviewSmell";
 import { useState } from "react";
 
+// 1.와인 리뷰에 필요한 값들을 상태값으로 정리.
+// 2.(rating,content)값은 ModalReviewRate컴포넌트 / (lightBold, smoothTannic, drySweet, softAcidic)값은 ModalReviewFlavor 컴포넌트 / (aroma[])값은 ModalReviewSmell 컴포넌트
+// 3. 각 컴포넌트에서 값을 전달 받아 최종적으로 ModalReviewForm 컴포넌트에서 POST요청을 할 수 있도록 설계.
+
+// 상태값들은 깊어야 2단계정도 prop으로 내려주기 때문에 context사용은 보류 3단계면 사용해야 한다고 판단.
+// 리팩토링때 좀 더 쉬운 방법 고안.
+
 export default function ModalReviewForm() {
   const [values, setValues] = useState({
     rating: 0,
     content: "",
+    lightBold: 0,
+    smoothTannic: 0,
+    drySweet: 0,
+    softAcidic: 0,
   });
   return (
-    <div>
+    <div className="flex flex-col gap-10">
       <ModalReviewRate
         rating={values.rating}
         setRating={(rating) => setValues((prev) => ({ ...prev, rating }))}
         content={values.content}
         setContent={(content) => setValues((prev) => ({ ...prev, content }))}
       />
-      <ModalReviewFlavor />
+      <ModalReviewFlavor
+        lightBold={values.lightBold}
+        setLightBold={(lightBold) =>
+          setValues((prev) => ({ ...prev, lightBold }))
+        }
+        smoothTannic={values.smoothTannic}
+        setSmoothTannic={(smoothTannic) =>
+          setValues((prev) => ({ ...prev, smoothTannic }))
+        }
+        drySweet={values.drySweet}
+        setDrySweet={(drySweet) => setValues((prev) => ({ ...prev, drySweet }))}
+        softAcidic={values.softAcidic}
+        setSoftAcidic={(softAcidic) =>
+          setValues((prev) => ({ ...prev, softAcidic }))
+        }
+      />
       <ModalReviewSmell />
       <Button>리뷰 남기기</Button>
     </div>


### PR DESCRIPTION
## #️⃣ 이슈

- close #43

## 📝 작업 내용
- ModalReviewForm컴포넌트의 상태값에 맛도 추가.
- ModalReviewFlavor 컴포넌트 완료.
- FlavorSlier 컴포넌트가 부모로부터 상태값을 받을 수 있도록 수정.

## 📸 결과물
<img width="798" alt="스크린샷 2025-02-07 오후 8 32 09" src="https://github.com/user-attachments/assets/e7c0075a-761b-4a29-b567-42b8a378cfad" />

상태값으로 맛도 받을 수있게 되었습니다.

## 👩‍💻 공유 포인트 및 논의 사항
- 부모컴포넌트인  ModalReviewForm컴포넌트에서 상태값을 2단계 밑에 있는 자식컴포넌트까지 전달해줍니다. 3단계정도면 context api를 사용하는데 2단계라 그냥 사용했습니다.