### PR TITLE
feat: ModalTwoButton 컴포넌트 작업

### DIFF
--- a/src/app/test/HoyoungTest.tsx
+++ b/src/app/test/HoyoungTest.tsx
@@ -1,8 +1,14 @@
 "use client";
 
+import { useState } from "react";
 import Dropdown from "@/components/Dropdown/dropdown";
+import ModalTwoButton from "@/components/Modal/ModalTwoButton/ModalTwoButton";
+import Button from "@/components/Button/button";
 
 export default function HoyeongTest() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalSize, setModalSize] = useState<"md" | "sm">("md");
+
   return (
     <div className="flex flex-col gap-6 p-6">
       {/* ✅ md 사이즈 기본 드롭다운 */}
@@ -52,6 +58,33 @@ export default function HoyeongTest() {
           isWineDropdown={true}
         />
       </div>
+
+      {/* ✅ Modal 테스트 섹션 */}
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-4">
+            {/* md 모달 열기 버튼 */}
+              <Button
+                onClick={() => {
+                  setModalSize("md");
+                  setIsModalOpen(true);
+                }} 
+              >
+                Modal(md)
+              </Button>
+            {/* sm 모달 열기 버튼 */}
+              <Button
+                onClick={() => {
+                  setModalSize("sm");
+                  setIsModalOpen(true);
+                }}
+              >
+                Modal(sm)
+              </Button>
+          </div>
+        </div>
+
+      {/* ModalTwoButton 컴포넌트 렌더링 */}
+      <ModalTwoButton size={modalSize} isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
     </div>
   );
 }

--- a/src/components/Modal/ModalTwoButton/ModalTwoButton.tsx
+++ b/src/components/Modal/ModalTwoButton/ModalTwoButton.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import Button from "@/components/Button/button";
+import clsx from "clsx";
+
+interface ModalTwoButtonProps {
+    size: "md" | "sm";
+    isOpen: boolean;
+    setIsOpen: (isOpen: boolean) => void;
+  }
+  
+  const ModalTwoButton: React.FC<ModalTwoButtonProps> = ({ size, isOpen, setIsOpen }) => {
+    if (!isOpen) return null;
+  
+    const sizeStyles = {
+      md: "w-[353px] h-[182px] p-[32px_16px_24px_16px] flex flex-col justify-between border border-[#CFDBEA] rounded-[16px]",
+      sm: "w-[353px] h-[172px] p-[32px_16px_24px_16px] flex flex-col justify-between border border-[#CFDBEA] rounded-[16px]",
+    };
+  
+    const buttonContainerStyles = {
+      md: "w-[321px] h-[54px] flex justify-between",
+      sm: "w-[321px] h-[50px] flex justify-between",
+    };
+    
+    const buttonSize = {
+      md: "w-[150px] h-[54px]",
+      sm: "w-[150px] h-[50px]",
+    };
+  
+    const textStyles = {
+      md: "text-xl-20px-bold text-center",
+      sm: "text-2lg-18px-bold text-center",
+    };
+  
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30">
+        <div className={clsx("bg-white shadow-md flex items-center gap-4", sizeStyles[size])}>
+          <p className={textStyles[size]}>정말 삭제하시겠습니까?</p>
+          <div className={buttonContainerStyles[size]}>
+            <Button variant="modalCancel" className={buttonSize[size]} onClick={() => setIsOpen(false)}>
+              취소
+            </Button>
+            <Button variant="modal" className={buttonSize[size]} onClick={() => {
+              alert("삭제되었습니다.");
+              setIsOpen(false);
+            }}>
+              삭제하기
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  };
+  
+  export default ModalTwoButton;


### PR DESCRIPTION
## #️⃣ 이슈

- #23 

## 📝 작업 내용
- 공통 컴포넌트 : Modal/two-button

## 📸 결과물
![image](https://github.com/user-attachments/assets/8419bf43-00b4-4119-a05a-d42442b62fd6)

![image](https://github.com/user-attachments/assets/e4d3d772-ef9b-4df5-a28c-a10cfefc14b9)

![image](https://github.com/user-attachments/assets/9a3ff63a-d3cc-4799-b362-e9e59f036a52)


## 👩‍💻 공유 포인트 및 논의 사항
 - md 크기와 sm 크기의 모달 창 구별이 확실하지 않아 체크해볼 필요가 있어 보입니다.
 - 모달 컴포넌트 자체의 이해도가 부족하여 특정 버튼(트리거) 클릭 시 모달 창이 나타나도록만 표현하였습니다.
 - 모달 창 외부를 클릭했을 때 모달 창에서 나가지도록 하는 코드를 추가할 예정입니다.