### PR TITLE
Feat(#80): 와인 등록 모달 수정

### DIFF
--- a/src/app/test/HyeseonTest.tsx
+++ b/src/app/test/HyeseonTest.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-
+import { useState, useEffect } from "react";
+import { useAuth } from "@/context/AuthProvider";
 import {
   Input,
   InputFile,
@@ -15,8 +15,44 @@ import {
 
 import ModalWineAdd from "@/components/Modal/ModalWineAdd/ModalWineAdd";
 import Gnb from "@/components/Gnb";
+import { createWine, fetchWineById, updateWine } from "@/lib/api/wine";
+import { useRouter } from "next/navigation"; // 라우팅 추가
+import { fetchMyWines } from "@/lib/api/user";
 
 export default function HyeseonTest() {
+  const { user } = useAuth();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [userWines, setUserWines] = useState<any[]>([]); // 사용자가 등록한 와인 목록
+  const [wineToEdit, setWineToEdit] = useState<any>(null); // 수정할 와인 데이터
+  const router = useRouter(); // useRouter를 올바르게 선언
+
+  useEffect(() => {
+    if (user) {
+      fetchMyWines(1) // 10개의 와인 목록 가져옴
+        .then((data) => {
+          if (data && data.list && data.list.length > 0) {
+            setUserWines(data.list); // list 배열에서 와인 목록 설정
+
+            // 와인 목록에 포함된 image 데이터 확인
+            console.log("불러온 와인 목록:", data.list);
+            data.list.forEach((wine: any) => {
+              console.log("와인 ID:", wine.id);
+              console.log("와인 이미지 URL:", wine.image); // imageUrl 확인
+            });
+          } else {
+            console.log("사용자가 만든 와인이 없습니다.");
+          }
+        })
+        .catch((error) => {
+          console.error(
+            "내가 만든 와인 목록을 불러오는 중 오류가 발생했습니다.",
+            error
+          );
+        });
+    }
+  }, [user]);
+
   // InputSearch 테스트용
   const handleSearch = (keyword?: string) => {
     console.log("Search keyword:", keyword);
@@ -25,13 +61,68 @@ export default function HyeseonTest() {
   // InputFile 테스트용
   const [file, setFile] = useState<File | null>(null);
   const handleFileChange = (name: string, file: File | null) => {
-    setFile(file);
+    setFile(file); // 상태 업데이트
     console.log("선택한 파일:", file);
   };
 
-  // ModalWineAdd 테스트용
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  useEffect(() => {
+    if (isEditMode && wineToEdit) {
+      // 수정 모드일 때 와인 데이터를 불러와서 해당 이미지 URL을 설정
+      setFile(wineToEdit.imageUrl || null); // wineToEdit.imageUrl은 이미지 URL을 저장한 필드
+    } else {
+      setFile(null); // 수정 모드가 아니면 파일 초기화
+    }
+  }, [isEditMode, wineToEdit]);
 
+  const handleWineSubmit = async (data: any) => {
+    try {
+      console.log("전송되는 데이터:", JSON.stringify(data, null, 2));
+
+      if (isEditMode && wineToEdit?.id) {
+        const { id, ...validData } = data; // ID 제거 후 요청
+        console.log("수정할 와인 ID:", wineToEdit.id);
+        console.log("PATCH 요청 바디:", validData);
+        await updateWine(wineToEdit.id, validData);
+        alert("와인 정보가 수정되었습니다.");
+      } else {
+        await createWine(data);
+        alert("새로운 와인이 등록되었습니다.");
+      }
+
+      setIsModalOpen(false);
+      setWineToEdit(null);
+      router.push("/");
+    } catch (error: any) {
+      console.error(
+        "❌ 와인 처리 중 오류:",
+        error.response?.data || error.message
+      );
+      alert(
+        "와인 처리 중 오류가 발생했습니다. 상세 오류: " +
+          (error.response?.data?.message || error.message)
+      );
+    }
+  };
+
+  // ModalWineAdd 테스트용
+  const handleWineModalOpen = (editMode: boolean) => {
+    if (!user) {
+      // 로그인되지 않은 경우 로그인 페이지로 리디렉션
+      router.push("/signin"); // 로그인 페이지로 이동
+      return;
+    }
+    setIsEditMode(editMode);
+    setIsModalOpen(true);
+
+    if (editMode && userWines.length > 0) {
+      // 수정 모드일 때, userWines에서 수정할 와인 데이터를 찾아 설정
+      const wineToEdit = userWines[0]; // 첫 번째 와인 데이터 사용
+      setWineToEdit(wineToEdit);
+    } else {
+      // 새로운 와인 등록 시 빈 데이터
+      setWineToEdit(null);
+    }
+  };
   return (
     <>
       <Gnb />
@@ -59,23 +150,38 @@ export default function HyeseonTest() {
         <InputFile
           id="file"
           name="file"
-          value={file}
+          value={file} // 부모에서 관리하는 file 상태
           onChange={handleFileChange}
         />
+
         <br />
         <Label htmlFor="file">프로필 사진 업로드</Label>
         <InputProfileImage />
       </div>
       <div className="mt-[40px]">
         <button
-          className="px-4 py-2 bg-blue-500 text-white rounded-md"
-          onClick={() => setIsModalOpen(true)}
+          className="px-4 py-2 bg-blue-500 text-white rounded-md mr-2"
+          onClick={() => handleWineModalOpen(false)} // 와인 등록 모드
+          disabled={!user} // 로그인되지 않으면 버튼 비활성화
         >
-          모달 열기
+          와인 등록하기
+        </button>
+        <button
+          className="px-4 py-2 bg-blue-500 text-white rounded-md"
+          onClick={() => handleWineModalOpen(true)} // 와인 수정 모드
+          disabled={!user} // 로그인되지 않으면 버튼 비활성화
+        >
+          수정하기
         </button>
         <ModalWineAdd
           isOpen={isModalOpen}
-          onClose={() => setIsModalOpen(false)}
+          onClose={() => {
+            setIsModalOpen(false);
+            setWineToEdit(null); // 모달 닫을 때 수정 데이터 초기화
+          }}
+          wineToEdit={wineToEdit} // 수정할 와인 데이터 전달
+          onSubmit={handleWineSubmit} // onSubmit 함수 전달
+          isEditMode={isEditMode} // 수정 모드 여부 전달
         />
       </div>
     </>

--- a/src/components/Button/button.tsx
+++ b/src/components/Button/button.tsx
@@ -19,7 +19,7 @@ interface ButtonProps {
 export default function Button({
   children,
   onClick,
-  variant = "button",
+  variant,
   size = "sm",
   disabled = false,
   className,

--- a/src/components/Input/InputFile.tsx
+++ b/src/components/Input/InputFile.tsx
@@ -9,6 +9,7 @@ interface InputFileProps {
   name: string;
   value: File | null;
   onChange: (name: string, value: File | null) => void;
+  initialData?: { image: string | null }; // 초기 데이터 (수정 모드일 때 사용할 이미지 URL)
 }
 
 export default function InputFile({
@@ -16,19 +17,23 @@ export default function InputFile({
   name,
   value,
   onChange,
+  initialData = { image: null },
 }: InputFileProps) {
   const [preview, setPreview] = useState<string | null>(null);
 
   useEffect(() => {
     if (value) {
+      // 로컬 파일인 경우
       const objectUrl = URL.createObjectURL(value);
       setPreview(objectUrl);
-
       return () => URL.revokeObjectURL(objectUrl);
+    } else if (initialData.image) {
+      // 수정 모드일 때 API로 받은 이미지 URL 사용
+      setPreview(initialData.image);
     } else {
       setPreview(null);
     }
-  }, [value]);
+  }, [value, initialData.image]);
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files?.length) {
@@ -40,6 +45,7 @@ export default function InputFile({
 
   const handleRemoveImage = () => {
     onChange(name, null);
+    setPreview(null); // 미리보기 이미지도 삭제
   };
 
   return (

--- a/src/components/Input/InputSelect.tsx
+++ b/src/components/Input/InputSelect.tsx
@@ -23,7 +23,7 @@ export default function InputSelect({
 }: InputSelectProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [currentValue, setCurrentValue] = useState<string | undefined>(
-    selectedValue || "Red"
+    selectedValue || "타입을 선택해주세요"
   );
 
   const handleSelect = (value: string) => {

--- a/src/components/Modal/ModalWineAdd/ModalWineAdd.tsx
+++ b/src/components/Modal/ModalWineAdd/ModalWineAdd.tsx
@@ -1,16 +1,42 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import ModalWineAddHeader from "./components/ModalWineAddHeader";
 import ModalWineAddForm from "./components/ModalWineAddForm";
 
 type ModalWindAddProps = {
   isOpen: boolean;
   onClose: () => void;
+  wineToEdit?: {
+    id: number;
+    name: string;
+    price: number;
+    region: string;
+    type: string;
+    image: string;
+  };
+  onSubmit: (wineData: any) => Promise<void>;
+  isEditMode: boolean;
 };
 
-export default function ModalWineAdd({ isOpen, onClose }: ModalWindAddProps) {
-  const handleWineSubmit = (data: {
+export default function ModalWineAdd({
+  isOpen,
+  onClose,
+  wineToEdit,
+  onSubmit,
+  isEditMode,
+}: ModalWindAddProps) {
+  const [editMode, setEditMode] = useState(false);
+
+  useEffect(() => {
+    if (wineToEdit) {
+      setEditMode(true);
+    } else {
+      setEditMode(false);
+    }
+  }, [wineToEdit]);
+
+  const handleWineSubmit = async (data: {
     name: string;
     price: number;
     region: string;
@@ -18,6 +44,7 @@ export default function ModalWineAdd({ isOpen, onClose }: ModalWindAddProps) {
     image: string;
   }) => {
     console.log(data);
+    await onSubmit(data); // onSubmit을 호출하여 부모에서 처리
     onClose();
   };
 
@@ -45,8 +72,21 @@ export default function ModalWineAdd({ isOpen, onClose }: ModalWindAddProps) {
   return (
     <div className="fixed inset-0 flex justify-center items-end md:items-center bg-black bg-opacity-50 z-50">
       <div className="flex flex-col gap-[32px] w-full md:w-[460px] p-6 rounded-lg bg-white shadow-lg max-h-screen overflow-y-auto">
-        <ModalWineAddHeader onClose={onClose} />
-        <ModalWineAddForm onSubmit={handleWineSubmit} onClose={onClose} />
+        <ModalWineAddHeader onClose={onClose} isEditMode={isEditMode} />
+        <ModalWineAddForm
+          onSubmit={handleWineSubmit}
+          onClose={onClose}
+          initialData={
+            wineToEdit || {
+              name: "",
+              price: 0,
+              region: "",
+              type: "",
+              image: "",
+            }
+          }
+          isEditMode={isEditMode}
+        />
       </div>
     </div>
   );

--- a/src/components/Modal/ModalWineAdd/components/ModalWineAddForm.tsx
+++ b/src/components/Modal/ModalWineAdd/components/ModalWineAddForm.tsx
@@ -1,37 +1,72 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Button from "@/components/Button/button";
 import { Input, InputFile, InputSelect, Label } from "@/components/Input";
 import { uploadImage } from "@/lib/api/image";
-import { createWine } from "@/lib/api/wine";
+import { useRouter } from "next/navigation";
 
 type ModalWineFormProps = {
+  initialData?: {
+    id?: number;
+    name: string;
+    price: number;
+    region: string;
+    type: string;
+    image: string;
+    avgRating: number;
+  };
   onSubmit: (data: {
     name: string;
     price: number;
     region: string;
     type: string;
     image: string;
-  }) => void;
+    avgRating: number;
+  }) => Promise<void>;
   onClose: () => void;
+  isEditMode: boolean;
 };
 
 export default function ModalWineAddForm({
-  onSubmit,
-  onClose,
-}: ModalWineFormProps) {
-  const [formData, setFormData] = useState({
+  initialData = {
     name: "",
-    price: "" as number | "",
+    price: 0,
     region: "",
     type: "",
-    image: "", // 최종적으로 URL을 저장할 필드
-  });
-
+    image: "",
+    avgRating: 0,
+  },
+  onSubmit,
+  onClose,
+  isEditMode,
+}: ModalWineFormProps) {
+  // 수정된 부분
+  const [formData, setFormData] = useState(initialData);
   const [file, setFile] = useState<File | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isEditMode && initialData.image) {
+      setFormData((prevData) => ({
+        ...prevData,
+        image: initialData.image,
+        avgRating: initialData.avgRating,
+      }));
+    }
+  }, [isEditMode, initialData]);
+
   const handleFileChange = (name: string, file: File | null) => {
     setFile(file);
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setFormData({ ...formData, image: reader.result as string });
+      };
+      reader.readAsDataURL(file);
+    } else {
+      setFormData({ ...formData, image: initialData.image });
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -49,23 +84,38 @@ export default function ModalWineAddForm({
     }
 
     try {
-      await createWine({
+      // POST 요청일 때는 imageUrl 포함해서 보내기
+      const wineData = {
+        id: initialData.id, // ✅ 수정 시 ID 포함
         name: formData.name,
+        price: formData.price || 0,
         region: formData.region,
+        type: formData.type,
         image: imageUrl,
-        price: formData.price === "" ? 0 : formData.price,
-        type: formData.type.toUpperCase(),
-      });
+        avgRating: formData.avgRating, // ✅ avgRating 추가
+      };
 
-      onSubmit({
-        ...formData,
-        price: formData.price === "" ? 0 : formData.price,
-        image: imageUrl, // 최종적으로 업로드 된 이미지 URL 저장
-      });
+      // 수정인 경우 PATCH, 새로운 등록일 경우 POST
+      await onSubmit(wineData);
+
+      // 성공적으로 저장되면 상세 페이지로 리디렉션 (POST 요청이 완료되면 상세 페이지로 이동)
+      router.push("/");
+      onClose();
     } catch (error) {
-      console.error("와인 등록 실패", error);
+      console.error("와인 정보 저장 실패", error);
     }
   };
+
+  // 필수 입력값 체크
+  const isFormValid =
+    formData.name.trim() !== "" &&
+    formData.price > 0 &&
+    formData.region.trim() !== "" &&
+    formData.type.trim() !== "" &&
+    (file !== null || formData.image !== "");
+
+  const isFormChanged =
+    JSON.stringify(formData) !== JSON.stringify(initialData);
 
   return (
     <form
@@ -73,68 +123,86 @@ export default function ModalWineAddForm({
       className="flex flex-col w-full gap-[24px] md:gap-[32px]"
     >
       <div>
-        <Label htmlFor="name">와인 이름</Label>
+        <Label htmlFor="name">
+          와인 이름 <sup className="text-purple-100">*</sup>
+        </Label>
         <Input
           id="name"
           type="text"
           value={formData.name}
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-          placeholder="와인 이름 입력"
+          placeholder="와인 이름을 입력해주세요"
           required
         />
       </div>
       <div>
-        <Label htmlFor="price">가격</Label>
+        <Label htmlFor="price">
+          가격 (단위:원) <sup className="text-purple-100">*</sup>
+        </Label>
         <Input
           id="price"
-          type="number"
-          value={formData.price}
-          onChange={(e) =>
-            setFormData({ ...formData, price: Number(e.target.value) })
-          }
-          placeholder="가격 입력"
+          type="text"
+          value={formData.price ? formData.price.toLocaleString() : ""}
+          onChange={(e) => {
+            // 숫자만 입력 가능하도록
+            const value = e.target.value.replace(/[^0-9]/g, ""); // 숫자 이외의 문자는 제거
+            // 쉼표 없이 숫자만 저장
+            const numericValue = value ? Number(value) : 0;
+            setFormData({ ...formData, price: numericValue });
+          }}
+          placeholder="가격을 입력해주세요"
           required
         />
       </div>
       <div>
-        <Label htmlFor="region">원산지</Label>
+        <Label htmlFor="region">
+          원산지 <sup className="text-purple-100">*</sup>
+        </Label>
         <Input
           id="region"
           type="text"
           value={formData.region}
           onChange={(e) => setFormData({ ...formData, region: e.target.value })}
-          placeholder="원산지 입력"
+          placeholder="원산지를 입력해주세요"
           required
         />
       </div>
       <div>
-        <Label htmlFor="type">타입</Label>
+        <Label htmlFor="type">
+          타입 <sup className="text-purple-100">*</sup>
+        </Label>
         <InputSelect
           id="type"
-          options={["Red", "White", "Sparkling"]}
+          options={["RED", "WHITE", "SPARKLING"]}
           selectedValue={formData.type}
           onChange={(value) => setFormData({ ...formData, type: value })}
         />
       </div>
       <div>
-        <Label htmlFor="image">와인 사진</Label>
+        <Label htmlFor="image">
+          와인 사진 <sup className="text-purple-100">*</sup>
+        </Label>
         <InputFile
           id="image"
           name="image"
           value={file}
           onChange={handleFileChange}
+          initialData={{ image: formData.image }} // 수정 모드일 때 이미지 전달
         />
       </div>
       <div className="flex justify-between gap-[3%] h-[54px]">
         <Button
-          variant="modalCancel"
-          className="w-[27%] h-full !bg-purple-10 text-purple-100 border-none"
+          className="w-[27%] h-full bg-purple-10 text-purple-100  hover:bg-white hover:border hover:border-purple-100"
           onClick={() => onClose()}
         >
           취소
         </Button>
-        <Button variant="modal" className="w-[70%] h-full">
-          와인 등록하기
+        <Button
+          variant="modal"
+          className="w-[70%] h-full hover:text-purple-100 hover:border hover:border-purple-100 hover:bg-white"
+          disabled={!isFormValid || !isFormChanged}
+        >
+          {isEditMode ? "수정하기" : "와인 등록하기"}
         </Button>
       </div>
     </form>

--- a/src/components/Modal/ModalWineAdd/components/ModalWineAddHeader.tsx
+++ b/src/components/Modal/ModalWineAdd/components/ModalWineAddHeader.tsx
@@ -4,12 +4,18 @@ import Icon from "@/components/Icon/Icon";
 
 type ModalWineAddProps = {
   onClose: () => void;
+  isEditMode: boolean;
 };
 
-export default function ModalWineAddHeader({ onClose }: ModalWineAddProps) {
+export default function ModalWineAddHeader({
+  onClose,
+  isEditMode,
+}: ModalWineAddProps) {
   return (
     <div className="flex justify-between items-center w-full">
-      <h1 className="text-xl-20px-bold md:text-2xl-24px-bold">와인 등록</h1>
+      <h1 className="text-xl-20px-bold md:text-2xl-24px-bold">
+        {isEditMode ? "내가 등록한 와인" : "와인 등록"}
+      </h1>
       <button type="button">
         <Icon
           className="text-gray-500 cursor-pointer "


### PR DESCRIPTION
## #️⃣ 이슈

- #80 

## 📝 작업 내용
- 와인 등록 모달 -> 와인 등록, 와인 수정 두 군데에서 사용 가능하도록 수정함

## 📸 결
![스크린샷 2025-02-12 오전 1 15 11](https://github.com/user-attachments/assets/54ec2606-39f4-428d-a70e-775023d1c7e1)
과물


## 👩‍💻 공유 포인트 및 논의 사항
- 버튼 스타일(버튼 상태에 따른 스타일)에 대해서 의논해야 할 것 같습니다.
-> 현재 버튼이 disabled 되는 상황도 있어서 hover시의 색상과 구분지어야 할 것 같습니다.
- 현재는 와인 상세페이지가 없어서 와인 수정시 사용자가 등록한 와인 목록 중에 1개(첫번째)만 불러오도록 되어있습니다.
-> 이 부분도 추후 페이지 완성되고 수정이 필요합니다.
- 페이지 모두 완성후에 리팩토링 해야할 것 같습니다. 현재는 작동만 되게 해놓은 상태라 코드가 깁니다. 
