### PR TITLE
Fix(#114): 카카오 로그인시 이메일 불러오기 수정, 기타 스타일 정리

### DIFF
--- a/src/app/MetaTags.tsx
+++ b/src/app/MetaTags.tsx
@@ -4,7 +4,10 @@ export default function MetaTags() {
   return (
     <>
       <meta charSet="UTF-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      />
       <meta name="description" content={metadata.description} />
       <meta name="keywords" content={metadata.keywords} />
       <meta name="author" content={metadata.author} />

--- a/src/app/myprofile/components/ProfileSetting.tsx
+++ b/src/app/myprofile/components/ProfileSetting.tsx
@@ -60,8 +60,12 @@ const ProfileSetting: React.FC<ProfileSettingProps> = ({
           onImageChange={handleImageChange}
         />
         <div className="flex flex-col lg:items-center gap-[8px] lg:gap-[16px]">
-          <h1 className="lg:text-2xl-24px-bold text-gray-800">{newNickname}</h1>
-          <p className="lg:text-lg-16px-regular text-gray-500">{email}</p>
+          <h1 className="text-xl-20px-bold md:text-2xl-24px-bold text-gray-800">
+            {newNickname}
+          </h1>
+          <p className="text-md-14px-regular md:text-lg-16px-regular text-gray-500">
+            {email}
+          </p>
         </div>
       </div>
       <div className="flex flex-col md:flex-row lg:flex-col items-end gap-[6px] md:gap-[24px] lg:gap-[8px] w-full">

--- a/src/components/Dropdown/DropdownWithLinks.tsx
+++ b/src/components/Dropdown/DropdownWithLinks.tsx
@@ -9,7 +9,7 @@ export default function DropdownWithLinks({ items }: DropdownWithLinksProps) {
         <a
           key={index}
           href={item.href}
-          className="block w-full px-4 py-2 text-gray-800 hover:bg-purple-10 hover:text-purple-100 rounded-[12px] transition"
+          className="block w-full px-2 md:px-4 py-2 text-gray-800 hover:bg-purple-10 hover:text-purple-100 rounded-[12px] transition"
           onClick={item.onClick}
         >
           {item.label}

--- a/src/components/Gnb/GnbUser.tsx
+++ b/src/components/Gnb/GnbUser.tsx
@@ -39,7 +39,7 @@ export default function GnbUser() {
           <Dropdown
             trigger={
               <button className="relative">
-                <div className="h-[45px] w-[45px] border border-gray-300 rounded-full overflow-hidden">
+                <div className="w-[35px] h-[35px] md:h-[45px] md:w-[45px] border border-gray-300 rounded-full overflow-hidden">
                   <Image
                     style={{ objectFit: "cover" }}
                     fill

--- a/src/components/Input/InputProfileImage.tsx
+++ b/src/components/Input/InputProfileImage.tsx
@@ -68,6 +68,7 @@ export default function InputProfileImage({
       onMouseLeave={() => setIsHover(false)}
       onClick={() => imageRef.current?.click()}
       className="relative w-[60px] h-[60px] md:w-[80px] md:h-[80px] lg:w-[164px] lg:h-[164px] rounded-full overflow-hidden border border-gray-300 cursor-pointer"
+      style={{ borderRadius: "50%", overflow: "hidden" }}
     >
       {isUploading ? (
         <div className="absolute inset-0 flex items-center justify-center bg-gray-200 animate-pulse">
@@ -77,12 +78,20 @@ export default function InputProfileImage({
         <>
           <Image
             src={imagePreview || "/images/common/no_profile.svg"}
-            layout="fill"
-            className="object-cover"
+            fill
+            style={{
+              objectFit: "cover",
+              borderRadius: "50%",
+              overflow: "hidden",
+            }}
+            className="!relative"
             alt="프로필 이미지"
           />
           {isHover && (
-            <div className="flex items-center justify-center absolute inset-0 bg-purple-100 bg-opacity-30">
+            <div
+              className="flex items-center justify-center absolute inset-0 bg-purple-100 bg-opacity-30 rounded-full"
+              style={{ objectFit: "cover" }}
+            >
               <Icon
                 name="photo"
                 size={40}

--- a/src/lib/api/kakaoAuth.ts
+++ b/src/lib/api/kakaoAuth.ts
@@ -14,6 +14,8 @@ export const signInWithKakao = async (code: string) => {
 
     console.log("✅ 카카오 로그인 성공, 액세스 토큰:", accessToken);
     console.log("✅ 사용자 정보:", user);
+    // 이메일을 로컬 스토리지에 저장
+    localStorage.setItem("email", user.email);
     return { accessToken, refreshToken, user }; // 필요에 따라 리턴할 데이터 처리
   } catch (error) {
     if (error instanceof AxiosError) {


### PR DESCRIPTION
## #️⃣ 이슈

- #114 

## 📝 작업 내용
- 카카오 로그인시 이메일 불러올 수 있게 작업
- 마이프로필 설정 부분에서 프로필 사진 모바일에서 overflow:hidden 처리 안되는 부분 수정
- 로그인시 Gnb 클릭 후 나타나는 드롭다운 모바일에서의 크기 수정

## 📸 결과물



## 👩‍💻 공유 포인트 및 논의 사항
- Auth.js 이용한 부분은 기본 로그인으로는 모두 가능했는데, 카카오 로그인 후에 백엔드로 다시 post 요청을 보내는 부분이 구현되지 않더라구요. next 15에서 안정적이지 못해서 그런걸 수도 있다고해서 일단 보류하겠습니다. 이 부분은 멘토님께 다시 여쭤보고 제출 기한을 지나도 해결해서 리팩토링해보도록 하겠습니다.

