### PR TITLE
Feat(#102):myprofile 페이지 mycard컴포넌트 제작 및 기존 modalreview 수정

### DIFF
--- a/src/app/myprofile/components/MyReivews.tsx
+++ b/src/app/myprofile/components/MyReivews.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState, useRef } from "react";
+import { fetchMyReviews } from "@/lib/api/user";
+import CardMyReview from "@/components/Card/CardMyReview/CardMyReview";
+import Image from "next/image";
+
+interface User {
+  id: number;
+  nickname: string;
+  image: string;
+}
+
+interface Wine {
+  id: number;
+  name: string;
+  image?: string;
+  avgRating?: number;
+}
+
+interface ReviewData {
+  id: number;
+  rating: number;
+  wineName: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  user: User;
+  wine: Wine;
+}
+
+export default function MyReviews() {
+  const [reviews, setReviews] = useState<ReviewData[]>([]);
+  const [cursor, setCursor] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const observerRef = useRef<HTMLDivElement | null>(null);
+  const didFetch = useRef(false);
+
+  useEffect(() => {
+    if (!didFetch.current) {
+      didFetch.current = true; // 첫 번째 실행만 허용
+      loadMoreReviews();
+    }
+  }, []);
+
+  const loadMoreReviews = async () => {
+    if (loading || !hasMore) return;
+    setLoading(true);
+
+    try {
+      const response = await fetchMyReviews(10, cursor);
+      console.log("🟠 서버에서 받은 리뷰 목록:", response.list); //서버 응답 확인
+
+      setReviews((prev: ReviewData[]) => {
+        const existingIds = new Set(prev.map((review) => review.id));
+        const newReviews = (response.list as ReviewData[])
+          .filter((review) => !existingIds.has(review.id))
+          .map((review) => ({
+            ...review,
+            wineName: review.wine?.name || "이름 없음",
+            wineId: review.wine?.id,
+          }));
+        return [...prev, ...newReviews];
+      });
+
+      if (response.nextCursor === null) {
+        setHasMore(false);
+      } else {
+        setCursor(response.nextCursor);
+      }
+    } catch (error) {
+      console.error("❌ 리뷰 로드 실패:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!observerRef.current || !hasMore || loading) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && !loading) {
+        loadMoreReviews();
+      }
+    });
+
+    observer.observe(observerRef.current);
+    return () => observer.disconnect();
+  }, [loading, hasMore]);
+
+  /*삭제 성공 후 UI 업데이트 */
+  const handleDeleteSuccess = (deletedReviewId: number) => {
+    setReviews((prevReviews) =>
+      prevReviews.filter((review) => review.id !== deletedReviewId)
+    );
+  };
+
+  console.log("🍷 첫 번째 리뷰의 wineId:", reviews[0]?.wine?.id);
+
+  return (
+    <div className="flex flex-col gap-4 items-center">
+      {/* 리뷰가 없을 때 이미지 표시 */}
+      {reviews.length === 0 && !loading && (
+        <div className="flex flex-col items-center gap-2">
+          <Image
+            src="/images/common/review-empty.svg"
+            alt="작성한 후기가 없습니다."
+            width={200} // 원하는 크기로 조정
+            height={200}
+          />
+          <p className="text-gray-500">작성한 후기가 없습니다.</p>
+        </div>
+      )}
+
+      {/* 리뷰 목록 */}
+      {reviews.map((review) => (
+        <CardMyReview
+          key={review.id}
+          review={{
+            ...review,
+            wine: {
+              id: review.wine?.id || 0, // ✅ 와인 ID가 없으면 기본값 0
+              name: review.wine?.name || "이름 없음", // ✅ 와인 이름이 없으면 "이름 없음"
+              image: review.wine?.image || "", // ✅ 와인 이미지가 없으면 빈 문자열
+            },
+          }}
+          onDeleteSuccess={() => handleDeleteSuccess(review.id)}
+        />
+      ))}
+
+      {loading && <p className="text-center text-gray-500">로딩 중...</p>}
+
+      <div ref={observerRef} className="h-10" />
+    </div>
+  );
+}

--- a/src/app/myprofile/components/TabContent.tsx
+++ b/src/app/myprofile/components/TabContent.tsx
@@ -1,19 +1,21 @@
 "use client";
 
+import MyReviews from "./MyReivews"; // 내가 쓴 후기 컴포넌트
+
 interface TabContentProps {
   activeTab: number;
 }
 
 export default function TabContent({ activeTab }: TabContentProps) {
   return (
-    <div>
+    <div className="w-full">
       {activeTab === 1 ? (
-        <div>
-          <h2>내가 쓴 후기</h2>
-        </div>
+        <MyReviews /> // ✅ 내가 쓴 후기 불러오기
       ) : activeTab === 2 ? (
         <div>
-          <h2>내가 등록한 와인</h2>
+          {" "}
+          {/* 내가 등록한 와인은 아직 미구현 상태 */}
+          <h2>내가 등록한 와인 (구현 예정)</h2>
         </div>
       ) : null}
     </div>

--- a/src/components/Card/CardMyReview/CardMyReview.tsx
+++ b/src/components/Card/CardMyReview/CardMyReview.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import MoreMenu from "@/components/Moremenu/MoreMenu";
+import Rating from "@/components/Card/Rating/Rating";
+import CardText from "@/components/Card/CardText/CardText";
+
+interface User {
+  id: number;
+  nickname: string;
+  image: string;
+}
+
+interface Wine {
+  id: number;
+  name: string;
+  image?: string;
+  avgRating?: number;
+}
+
+interface ReviewData {
+  id: number;
+  rating: number;
+  wineName: string;
+  content: string;
+  updatedAt: string;
+  user: User;
+  wine: Wine;
+}
+
+interface CardMyReviewProps {
+  review: ReviewData;
+  onDeleteSuccess?: () => void; // ✅ 삭제 후 UI 업데이트를 위한 프롭 추가
+}
+
+const formatTimeAgo = (updatedAt: string) => {
+  const updatedDate = new Date(updatedAt);
+  const now = new Date();
+  const diffInMs = now.getTime() - updatedDate.getTime();
+  const diffInSeconds = Math.floor(diffInMs / 1000);
+  const diffInMinutes = Math.floor(diffInSeconds / 60);
+  const diffInHours = Math.floor(diffInMinutes / 60);
+  const diffInDays = Math.floor(diffInHours / 24);
+  const diffInMonths = Math.floor(diffInDays / 30);
+  const diffInYears = Math.floor(diffInMonths / 12);
+
+  if (diffInSeconds < 60) return "방금 전";
+  if (diffInMinutes < 60) return `${diffInMinutes}분 전`;
+  if (diffInHours < 24) return `${diffInHours}시간 전`;
+  if (diffInDays < 30) return `${diffInDays}일 전`;
+  if (diffInMonths < 12) return `${diffInMonths}개월 전`;
+  return `${diffInYears}년 전`;
+};
+
+const CardMyReview = ({ review, onDeleteSuccess }: CardMyReviewProps) => {
+  return (
+    <div className="flex flex-col w-full max-w-[800px] p-4 border rounded-lg shadow bg-white space-y-4">
+      {/* 1. 평점 + 작성 시간 */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Rating rating={review.rating} />
+          <span className="text-gray-500 text-sm">
+            {formatTimeAgo(review.updatedAt)}
+          </span>
+        </div>
+        <MoreMenu
+          reviewId={review.id}
+          wineId={review.wine.id}
+          userId={review.user.id}
+          onDeleteSuccess={onDeleteSuccess}
+        />
+      </div>
+
+      {/* 2. 와인 이름 */}
+      <h3 className="lg-16px-medium text-gray-500">
+        {review.wineName || "이름 없음"}
+      </h3>
+
+      {/* 3. 리뷰 내용 */}
+      <CardText className="text-gray-800 font-medium break-words whitespace-normal w-full">
+        {review.content}
+      </CardText>
+    </div>
+  );
+};
+
+export default CardMyReview;

--- a/src/components/Card/CardReview/CardReview.tsx
+++ b/src/components/Card/CardReview/CardReview.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import MoreMenu from "@/components/Moremenu/MoreMenu";
 import LikeButton from "@/components/Like/LikeButton";
 import ProfileDisplay from "@/components/Card/ProfileDisplay/ProfileDisplay";
@@ -7,6 +8,7 @@ import CardText from "@/components/Card/CardText/CardText";
 import AromaTag from "@/components/Card/AromaTag/AromaTag";
 import FlavorSlider from "@/components/Card/Flavor/FlavorSlider";
 import Rating from "@/components/Card/Rating/Rating";
+import Icon from "@/components/Icon/Icon";
 
 interface User {
   id: number;
@@ -30,6 +32,8 @@ interface ReviewData {
 }
 
 const ReviewCard = ({ review }: { review: ReviewData }) => {
+  const [isExpanded, setIsExpanded] = useState(false); //  접기/펼치기 상태 추가
+
   return (
     <div className="flex flex-col w-auto max-w-[800px] p-4 border rounded-lg shadow bg-white space-y-6">
       {/* 1. 프로필 + 좋아요 + MoreMenu */}
@@ -55,24 +59,39 @@ const ReviewCard = ({ review }: { review: ReviewData }) => {
         <Rating rating={review.rating} />
       </div>
 
-      {/* 3. 리뷰 내용 */}
-      <CardText className="text-gray-900 font-medium break-words whitespace-normal w-full">
-        {review.content}
-      </CardText>
+      {/* 3. 리뷰 내용 & FlavorSlider (isExpanded가 true일 때만 표시) */}
+      {isExpanded && (
+        <>
+          <CardText className="text-gray-900 font-medium break-words whitespace-normal w-full">
+            {review.content}
+          </CardText>
 
-      {/* 4. FlavorSlider (비율 유지) */}
-      <div className="flex w-full flex-col items-center justify-center min-w-0 overflow-hidden">
-        <div className="w-full flex-grow min-w-0">
-          <FlavorSlider
-            lightBold={review.lightBold}
-            smoothTannic={review.smoothTannic}
-            drySweet={review.drySweet}
-            softAcidic={review.softAcidic}
-            isReadOnly={true}
-            className="w-full flex-grow min-w-0"
-          />
-        </div>
-      </div>
+          <div className="flex w-full flex-col items-center justify-center min-w-0 overflow-hidden">
+            <div className="w-full flex-grow min-w-0">
+              <FlavorSlider
+                lightBold={review.lightBold}
+                smoothTannic={review.smoothTannic}
+                drySweet={review.drySweet}
+                softAcidic={review.softAcidic}
+                isReadOnly={true}
+                className="w-full flex-grow min-w-0"
+              />
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* 4. 접기/펼치기 버튼 */}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex items-center justify-center w-full py-2 transition-transform duration-200"
+      >
+        <Icon
+          name="more" // 기존 아이콘 사용
+          size={40}
+          className={`text-gray-500 transition-transform duration-200 ${isExpanded ? "rotate-180" : "rotate-0"}`}
+        />
+      </button>
     </div>
   );
 };

--- a/src/components/Card/ProfileDisplay/ProfileDisplay.tsx
+++ b/src/components/Card/ProfileDisplay/ProfileDisplay.tsx
@@ -3,16 +3,21 @@
 import React from "react";
 
 interface ProfileDisplayProps {
-  image: string;
+  image?: string;
   nickname: string;
   updatedAt: string; // 마지막 업데이트 시간 (ISO 형식)
 }
+
+const DEFAULT_PROFILE_IMAGE = "/images/common/no_profile.svg";
 
 const ProfileDisplay: React.FC<ProfileDisplayProps> = ({
   image,
   nickname,
   updatedAt,
 }) => {
+  const profileImage =
+    image && image.trim() !== "" ? image : DEFAULT_PROFILE_IMAGE;
+
   const getTimeAgo = (dateString: string) => {
     const updatedDate = new Date(dateString);
     const now = new Date();
@@ -49,7 +54,11 @@ const ProfileDisplay: React.FC<ProfileDisplayProps> = ({
 
   return (
     <div className="flex items-center gap-3">
-      <img src={image} alt="Profile" className="w-10 h-10 rounded-full" />
+      <img
+        src={profileImage}
+        alt="Profile"
+        className="w-10 h-10 rounded-full"
+      />
       <div className="flex flex-col">
         <span className="text-lg font-semibold">{nickname}</span>
         <span className="text-gray-500 text-sm">{getTimeAgo(updatedAt)}</span>

--- a/src/components/Modal/ModalReviewAdd/ModalReviewAdd.tsx
+++ b/src/components/Modal/ModalReviewAdd/ModalReviewAdd.tsx
@@ -9,13 +9,15 @@ import ModalReviewForm from "./components/ModalReviewForm";
 type ModalReviewAddProps = {
   isOpen: boolean;
   onClose: () => void;
-  initialReviewId?:number;
+  initialReviewId?: number;
+  wineId?: number;
 };
 
 export default function ModalReviewAdd({
   isOpen,
   onClose,
   initialReviewId,
+  wineId,
 }: ModalReviewAddProps) {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -38,7 +40,11 @@ export default function ModalReviewAdd({
     <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-50 ">
       <div className="flex flex-col gap-10 w-full max-w-[528px]  p-6 rounded-lg bg-white shadow-lg ">
         <ModalReviewHeader onClose={onClose} />
-        <ModalReviewForm onClose={onClose} initialReviewId={initialReviewId} />
+        <ModalReviewForm
+          onClose={onClose}
+          initialReviewId={initialReviewId}
+          initialWineId={wineId}
+        />
       </div>
     </div>
   );

--- a/src/components/Modal/ModalReviewAdd/components/ModalReviewForm.tsx
+++ b/src/components/Modal/ModalReviewAdd/components/ModalReviewForm.tsx
@@ -30,16 +30,22 @@ type ReviewData = {
 type ModalReviewFormProps = {
   onClose: () => void;
   initialReviewId?: number;
+  initialWineId?: number;
 };
 
 export default function ModalReviewForm({
   onClose,
   initialReviewId,
+  initialWineId,
 }: ModalReviewFormProps) {
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
   const [reviewId, setReviewId] = useState<number | null>(
     initialReviewId ?? null
   );
+
+  // ✅ `initialWineId`가 있으면 바로 사용, 없으면 `null`
+  const [wineId, setWineId] = useState<number | null>(initialWineId ?? null);
+
   const [wine, setWine] = useState<{
     id: number;
     name: string;
@@ -70,10 +76,20 @@ export default function ModalReviewForm({
   });
 
   const { id } = useParams();
-  const wineId = Array.isArray(id) ? id[0] : id;
+  const paramWineId = Array.isArray(id) ? id[0] : id; //변수중복 방지
 
   // 버튼 비활성화
   const disabled = !(values.rating && values.content);
+
+  // ✅ `initialWineId`가 있으면 바로 설정
+  useEffect(() => {
+    if (initialWineId) {
+      setWineId(initialWineId);
+    } else if (paramWineId) {
+      console.log("🔄 paramWineId 사용:", paramWineId);
+      setWineId(Number(paramWineId)); // ✅ paramWineId를 wineId로 설정
+    }
+  }, [initialWineId, paramWineId]);
 
   // 기존 리뷰 데이터를 가져오는 함수
   const fetchReviewData = async (reviewId: number) => {
@@ -82,7 +98,8 @@ export default function ModalReviewForm({
       const response = await fetchReviewById(reviewId);
       console.log("기존리뷰 데이터 가져오기:", response);
 
-      setValues({
+      setValues((prev) => ({
+        ...prev,
         rating: response.rating,
         content: response.content,
         lightBold: response.lightBold,
@@ -90,8 +107,12 @@ export default function ModalReviewForm({
         drySweet: response.drySweet,
         softAcidic: response.softAcidic,
         aroma: response.aroma,
-        wineId: response.wineId,
-      });
+        wineId: response.wineId ?? prev.wineId, // ✅ 기존 wineId 유지
+      }));
+      // ✅ `initialWineId`가 없을 때만 `setWineId` 실행
+      if (!initialWineId) {
+        setWineId(response.wineId);
+      }
     } catch (error) {
       if (error instanceof AxiosError) {
         console.error(
@@ -102,19 +123,34 @@ export default function ModalReviewForm({
     }
   };
 
+  // ✅ `reviewId`가 변경될 때 기존 리뷰 데이터를 가져옴
+  useEffect(() => {
+    if (reviewId && isEditMode) {
+      fetchReviewData(reviewId);
+    }
+  }, [reviewId, isEditMode]);
+
+  // ✅ `wineId`가 존재할 경우에만 `fetchWineById` 실행
   useEffect(() => {
     const fetchWine = async () => {
       try {
-        if (!wineId) return;
-        const response = await fetchWineById(wineId);
-        const { id, name, image } = response;
-        setWine({ id, name, image });
+        if (!wineId || wineId === 0) {
+          console.log("🚨 fetchWineById 실행 안 함 - wineId가 0임");
+          return;
+        }
+        console.log("✅ fetchWineById 실행:", wineId);
+        const response = await fetchWineById(String(wineId));
+        setWine({
+          id: response.id,
+          name: response.name,
+          image: response.image,
+        });
       } catch (error) {
-        console.error("와인 데이터를 가져오는 중 오류 발생:", error);
+        console.error("❌ 와인 데이터를 가져오는 중 오류 발생:", error);
       }
     };
-    fetchWine();
-  }, [wineId, reviewId]);
+    if (wineId) fetchWine(); // ✅ wineId가 있을 때만 실행
+  }, [wineId]);
 
   useEffect(() => {
     if (reviewId && isEditMode) {
@@ -122,6 +158,7 @@ export default function ModalReviewForm({
     }
   }, [reviewId, isEditMode]);
 
+  // ✅ `initialReviewId`가 있으면 수정 모드 활성화
   useEffect(() => {
     if (initialReviewId) {
       setReviewId(initialReviewId);
@@ -129,8 +166,10 @@ export default function ModalReviewForm({
     }
   }, [initialReviewId]);
 
+  // ✅ 리뷰 저장 & 수정 API 요청
   const onSubmit = async () => {
     if (!wine.id || wine.id === 0) {
+      console.log("wine.id=", wine.id);
       alert("와인 정보를 불러오는 중입니다. 잠시만 기다려 주세요.");
       return;
     }
@@ -152,7 +191,7 @@ export default function ModalReviewForm({
       if (isEditMode) {
         // 수정 요청 PATCH
         const response = await updateReview(reviewId!, reviewData);
-        console.log("리뷰 수정완료", response);
+        console.log("리뷰 수정 완료", response);
         alert("리뷰가 수정되었습니다.");
       }
       if (!isEditMode && reviewData.wineId !== undefined) {
@@ -160,7 +199,7 @@ export default function ModalReviewForm({
           ...reviewData,
           wineId: reviewData.wineId,
         });
-        console.log("리뷰등록 완료", response);
+        console.log("리뷰 등록 완료", response);
         alert("리뷰가 성공적으로 등록되었습니다.");
       }
       onClose();
@@ -169,7 +208,6 @@ export default function ModalReviewForm({
       if (error instanceof AxiosError) {
         console.error("리뷰 수정 실패:", error.response?.data);
       }
-    } finally {
     }
   };
 

--- a/src/components/Moremenu/MoreMenu.tsx
+++ b/src/components/Moremenu/MoreMenu.tsx
@@ -8,12 +8,14 @@ import { deleteReview } from "@/lib/api/review";
 interface MoreMenuProps {
   reviewId: number; // 리뷰 ID
   userId: number; // 리뷰 작성자 ID
+  wineId?: number;
   onDeleteSuccess?: () => void; // 삭제 성공 후 UI 업데이트 함수
 }
 
 const MoreMenu: React.FC<MoreMenuProps> = ({
   reviewId,
   userId,
+  wineId,
   onDeleteSuccess,
 }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -41,7 +43,6 @@ const MoreMenu: React.FC<MoreMenuProps> = ({
       console.error("리뷰 삭제 실패:", error);
     }
   };
-
   return (
     <div className="relative">
       {/* ✅ 모든 리뷰에서 햄버거 메뉴(⋮) 보이게 수정 */}
@@ -82,6 +83,7 @@ const MoreMenu: React.FC<MoreMenuProps> = ({
         <ModalReviewAdd
           isOpen={isEditModalOpen}
           onClose={() => setIsEditModalOpen(false)}
+          wineId={wineId}
           initialReviewId={reviewId} // 기존 리뷰 ID 전달 → 수정 모드로 동작
         />
       )}

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -26,10 +26,10 @@ export const updateUserProfile = async (nickname: string, imageUrl: string) => {
 };
 
 // ✅ 내가 작성한 리뷰 조회
-export const fetchMyReviews = async (limit: number, cursor?: string) => {
+export const fetchMyReviews = async (limit: number, cursor?: number | null) => {
   try {
-    const params: { limit: number; cursor?: string } = { limit };
-    if (cursor) params.cursor = cursor; // cursor 값이 있을 때만 추가
+    const params: { limit: number; cursor?: number } = { limit };
+    if (cursor !== null) params.cursor = cursor; // ✅ cursor가 null이면 요청에서 제외
 
     const response = await apiClient.get("/users/me/reviews", { params });
     return response.data;


### PR DESCRIPTION
## #️⃣ 이슈

- close #102  

## 📝 작업 내용
 -  내가 쓴 후기를 보여주기위한 CardMyReview 컴포넌트 생성 
 - tabcontent 를 통해 후기/와인 탭 분리 후 렌더링
 - initialwineid prop을 넘겨 modalreviewform 에서 수정모드 로직 수정 (initialwineid 넘어왔을때 아닐때 둘 다 동작)
 - 리뷰카드 접기 펼치기 기능 추가
 - 삭제 시 바로 ui렌더링 기능 추가
 - 리뷰카드 작성자 프로필 미지정 시 기본프로필 설정
 
## 📸 결과물
![화면 캡처 2025-02-17 021125](https://github.com/user-attachments/assets/01f5e72b-e4b5-47a2-856f-670f19442c9d)
![화면 캡처 2025-02-17 021152](https://github.com/user-attachments/assets/322f6194-05c3-41f0-a090-980dccae8305)


## 👩‍💻 공유 포인트 및 논의 사항
