### PR TITLE
Feat(#129):myprofile wines 내가 등록한 와인 카드 컴포넌트 연동 및 전체 페이지 구현

### DIFF
--- a/src/app/myprofile/components/MyReivews.tsx
+++ b/src/app/myprofile/components/MyReivews.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { fetchMyReviews } from "@/lib/api/user";
 import CardMyReview from "@/components/Card/CardMyReview/CardMyReview";
 import Image from "next/image";
@@ -35,20 +35,13 @@ export default function MyReviews() {
   const observerRef = useRef<HTMLDivElement | null>(null);
   const didFetch = useRef(false);
 
-  useEffect(() => {
-    if (!didFetch.current) {
-      didFetch.current = true; // 첫 번째 실행만 허용
-      loadMoreReviews();
-    }
-  }, []);
-
-  const loadMoreReviews = async () => {
+  const loadMoreReviews = useCallback(async () => {
     if (loading || !hasMore) return;
     setLoading(true);
 
     try {
       const response = await fetchMyReviews(10, cursor);
-      console.log("🟠 서버에서 받은 리뷰 목록:", response.list); //서버 응답 확인
+      console.log("🟠 서버에서 받은 리뷰 목록:", response.list);
 
       setReviews((prev: ReviewData[]) => {
         const existingIds = new Set(prev.map((review) => review.id));
@@ -72,55 +65,62 @@ export default function MyReviews() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [cursor, hasMore, loading]); // ✅ 의존성 배열 추가
 
+  // ✅ 최초 1회 데이터 로드
+  useEffect(() => {
+    if (!didFetch.current) {
+      didFetch.current = true;
+      loadMoreReviews(); // ✅ 최초 실행
+    }
+  }, [loadMoreReviews]);
+
+  // ✅ Intersection Observer로 무한 스크롤 구현
   useEffect(() => {
     if (!observerRef.current || !hasMore || loading) return;
 
     const observer = new IntersectionObserver((entries) => {
       if (entries[0].isIntersecting && !loading) {
-        loadMoreReviews();
+        loadMoreReviews(); // ✅ 옵저버가 감지되면 리뷰 로드
       }
     });
 
     observer.observe(observerRef.current);
     return () => observer.disconnect();
-  }, [loading, hasMore]);
+  }, [loading, hasMore, loadMoreReviews]); // ✅ 의존성 배열에 loadMoreReviews 추가
 
-  /*삭제 성공 후 UI 업데이트 */
+  /* ✅ 삭제 성공 후 UI 업데이트 */
   const handleDeleteSuccess = (deletedReviewId: number) => {
     setReviews((prevReviews) =>
       prevReviews.filter((review) => review.id !== deletedReviewId)
     );
   };
 
-  console.log("🍷 첫 번째 리뷰의 wineId:", reviews[0]?.wine?.id);
-
   return (
     <div className="flex flex-col gap-4 items-center">
-      {/* 리뷰가 없을 때 이미지 표시 */}
+      {/* ✅ 리뷰가 없을 때 이미지 표시 */}
       {reviews.length === 0 && !loading && (
         <div className="flex flex-col items-center gap-2">
           <Image
             src="/images/common/review-empty.svg"
             alt="작성한 후기가 없습니다."
-            width={200} // 원하는 크기로 조정
+            width={200}
             height={200}
           />
           <p className="text-gray-500">작성한 후기가 없습니다.</p>
         </div>
       )}
 
-      {/* 리뷰 목록 */}
+      {/* ✅ 리뷰 목록 */}
       {reviews.map((review) => (
         <CardMyReview
           key={review.id}
           review={{
             ...review,
             wine: {
-              id: review.wine?.id || 0, // ✅ 와인 ID가 없으면 기본값 0
-              name: review.wine?.name || "이름 없음", // ✅ 와인 이름이 없으면 "이름 없음"
-              image: review.wine?.image || "", // ✅ 와인 이미지가 없으면 빈 문자열
+              id: review.wine?.id || 0,
+              name: review.wine?.name || "이름 없음",
+              image: review.wine?.image || "",
             },
           }}
           onDeleteSuccess={() => handleDeleteSuccess(review.id)}

--- a/src/app/myprofile/components/MyReivews.tsx
+++ b/src/app/myprofile/components/MyReivews.tsx
@@ -65,31 +65,31 @@ export default function MyReviews() {
     } finally {
       setLoading(false);
     }
-  }, [cursor, hasMore, loading]); // ✅ 의존성 배열 추가
+  }, [cursor, hasMore, loading]); // 의존성 배열 추가
 
-  // ✅ 최초 1회 데이터 로드
+  // 최초 1회 데이터 로드
   useEffect(() => {
     if (!didFetch.current) {
       didFetch.current = true;
-      loadMoreReviews(); // ✅ 최초 실행
+      loadMoreReviews(); // 최초 실행
     }
   }, [loadMoreReviews]);
 
-  // ✅ Intersection Observer로 무한 스크롤 구현
+  // Intersection Observer로 무한 스크롤 구현
   useEffect(() => {
     if (!observerRef.current || !hasMore || loading) return;
 
     const observer = new IntersectionObserver((entries) => {
       if (entries[0].isIntersecting && !loading) {
-        loadMoreReviews(); // ✅ 옵저버가 감지되면 리뷰 로드
+        loadMoreReviews(); // 옵저버가 감지되면 리뷰 로드
       }
     });
 
     observer.observe(observerRef.current);
     return () => observer.disconnect();
-  }, [loading, hasMore, loadMoreReviews]); // ✅ 의존성 배열에 loadMoreReviews 추가
+  }, [loading, hasMore, loadMoreReviews]); // 의존성 배열에 loadMoreReviews 추가
 
-  /* ✅ 삭제 성공 후 UI 업데이트 */
+  /* 삭제 성공 후 UI 업데이트 */
   const handleDeleteSuccess = (deletedReviewId: number) => {
     setReviews((prevReviews) =>
       prevReviews.filter((review) => review.id !== deletedReviewId)

--- a/src/app/myprofile/components/MyWines.tsx
+++ b/src/app/myprofile/components/MyWines.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import MyList from "@/components/Card/Mylist/MyList"; // 개별 와인 카드
+import { fetchMyWines } from "@/lib/api/user"; // API 요청 함수
+import { WineData } from "@/lib/api/wine"; // 기존 WineData 타입 가져오기
+
+// 기존 WineData를 확장하는 새로운 타입 생성 (userId 포함)
+interface WineDataWithUserId extends WineData {
+  userId: number;
+}
+
+export default function MyWines() {
+  const [wines, setWines] = useState<WineDataWithUserId[]>([]);
+
+  const fetchWinesData = async () => {
+    try {
+      const response = await fetchMyWines(10);
+
+      if (!response || !response.list) {
+        console.error("❌ API 응답이 올바르지 않습니다:", response);
+        return;
+      }
+      setWines(response.list);
+    } catch (error) {
+      console.error("❌ 내가 등록한 와인 불러오기 실패:", error);
+    }
+  };
+
+  useEffect(() => {
+    fetchWinesData();
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {wines.length === 0 ? (
+        <p className="text-gray-500">등록한 와인이 없습니다.</p>
+      ) : (
+        wines.map((wine) => (
+          <MyList
+            key={wine.id}
+            wine={wine}
+            onDeleteSuccess={fetchWinesData} // 삭제 후 리스트 업데이트 함수 전달
+          />
+        ))
+      )}
+    </div>
+  );
+}

--- a/src/app/myprofile/components/TabContent.tsx
+++ b/src/app/myprofile/components/TabContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 import MyReviews from "./MyReivews"; // 내가 쓴 후기 컴포넌트
-import MyWines from "./MyWines"; // ✅ 내가 등록한 와인 목록을 가져오는 컴포넌트
+import MyWines from "./MyWines"; // 내가 등록한 와인 목록을 가져오는 컴포넌트
 
 interface TabContentProps {
   activeTab: number;

--- a/src/app/myprofile/components/TabContent.tsx
+++ b/src/app/myprofile/components/TabContent.tsx
@@ -1,7 +1,6 @@
 "use client";
-import MyList from "@/components/Card/Mylist/MyList";
-
 import MyReviews from "./MyReivews"; // 내가 쓴 후기 컴포넌트
+import MyWines from "./MyWines"; // ✅ 내가 등록한 와인 목록을 가져오는 컴포넌트
 
 interface TabContentProps {
   activeTab: number;
@@ -13,20 +12,7 @@ export default function TabContent({ activeTab }: TabContentProps) {
       {activeTab === 1 ? (
         <MyReviews /> // ✅ 내가 쓴 후기 불러오기
       ) : activeTab === 2 ? (
-        <div>
-          <h2>내가 등록한 와인</h2>
-          <MyList
-            wine={{
-              reviewId: 819,
-              userId: 916,
-              name: "test",
-              price: 1000,
-              region: "수원",
-              image:
-                "	https://www.gangnam.wine/shopimages/vinit777/001002000432.png?1734080483",
-            }}
-          />
-        </div>
+        <MyWines /> // ✅ MyWines.tsx를 호출하여 등록한 와인 목록을 불러오기
       ) : null}
     </div>
   );

--- a/src/app/myprofile/page.tsx
+++ b/src/app/myprofile/page.tsx
@@ -22,19 +22,16 @@ export default function MyProfile() {
 
   useEffect(() => {
     if (!user && !isLoading) {
-      // 로딩 상태가 아닐 때만 리디렉션
       router.push("/signin");
     } else if (user) {
-      // 유저가 로그인 되어있으면 리뷰와 와인 목록 가져오기
       Promise.all([fetchMyReviews(100), fetchMyWines(100)]).then(
         ([reviews, wines]) => {
-          setReviewCount(reviews.length || 0);
-          setWineCount(wines.length || 0);
+          setReviewCount(reviews.totalCount || 0); //
+          setWineCount(wines.totalCount || 0);
         }
       );
     }
   }, [user, isLoading, router]);
-
   if (isLoading) {
     return <div>Loading...</div>;
   }

--- a/src/app/test/YuseopTest.tsx
+++ b/src/app/test/YuseopTest.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Button from "@/components/Button/button";
-import MoreMenu from "@/components/Moremenu/MoreMenu";
+//import MoreMenu from "@/components/Moremenu/MoreMenu";
 import LikeButton from "@/components/Like/LikeButton";
 
 export default function YuseopTest() {
@@ -48,7 +48,7 @@ export default function YuseopTest() {
       {/* ✅ MoreMenu 테스트 추가 */}
       <div className="flex flex-col gap-4 p-4 border rounded-lg shadow-md">
         <h3 className="text-lg font-bold">📌 MoreMenu 테스트</h3>
-        <MoreMenu reviewId={1670} userId={964} />
+        {/* <MoreMenu reviewId={1670} userId={964} /> */}
       </div>
       {/* ✅ 좋아요 버튼 테스트 */}
       <div className="flex flex-col items-center gap-4 p-4 border rounded-lg shadow-md">

--- a/src/app/test/wineadd/modalwineeditmode/page.tsx
+++ b/src/app/test/wineadd/modalwineeditmode/page.tsx
@@ -37,7 +37,7 @@ export default function WineEditPage() {
 
     async function fetchWine() {
       try {
-        const wine = await fetchWineById(wineId.toString());
+        const wine = await fetchWineById(wineId);
         setWineToEdit(wine);
       } catch (error) {
         console.error("와인 정보를 가져오는 중 오류 발생:", error);
@@ -61,7 +61,7 @@ export default function WineEditPage() {
     console.log("🔍 수정 요청 데이터:", wineData); // id를 제외한 데이터
 
     try {
-      await updateWine(wineId.toString(), wineData); // id를 제외한 데이터만 전달
+      await updateWine(wineId, wineData); // id를 제외한 데이터만 전달
       alert("👌🏻 와인 정보가 수정되었습니다.");
       router.push(`/`); // 수정 후 페이지 이동
     } catch (error) {

--- a/src/app/winelist/[id]/components/ReviewList.tsx
+++ b/src/app/winelist/[id]/components/ReviewList.tsx
@@ -25,7 +25,7 @@ interface ReviewData {
 }
 
 type ReviewListProps = {
-  wineId: string;
+  wineId: number;
   reviewsId: number[];
 };
 

--- a/src/app/winelist/[id]/components/ReviewStats.tsx
+++ b/src/app/winelist/[id]/components/ReviewStats.tsx
@@ -5,7 +5,7 @@ import { fetchWineById } from "@/lib/api/wine";
 import StarRating from "@/components/Modal/ModalReviewAdd/components/StarRating";
 
 type ReviewStatsProps = {
-  wineId: string;
+  wineId: number;
 };
 
 export default function ReviewStats({ wineId }: ReviewStatsProps) {

--- a/src/app/winelist/[id]/page.tsx
+++ b/src/app/winelist/[id]/page.tsx
@@ -3,7 +3,7 @@ import CardDetail from "@/components/Card/CardDetail";
 import { useParams } from "next/navigation";
 import ReviewStats from "./components/ReviewStats";
 import ReviewList from "./components/ReviewList";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { fetchWineById } from "@/lib/api/wine";
 import Image from "next/image";
 import Button from "@/components/Button/button";
@@ -19,19 +19,21 @@ export default function Page() {
   const { id } = useParams();
 
   // id 값이 배열일 경우 첫 번째 요소를 가져옴
-  const wineId: string = Array.isArray(id) ? id[0] : id || "";
+  const wineId: number = Array.isArray(id)
+    ? parseInt(id[0] ?? "", 10)
+    : parseInt(id ?? "", 10) || 0;
 
   // 리뷰 id 가져오기
-  const fetchReviewsId = async () => {
+  const fetchReviewsId = useCallback(async () => {
     try {
       const data = await fetchWineById(wineId);
       if (data.reviews) {
         setReviewsId(data.reviews.map((review: { id: number }) => review.id));
       }
     } catch (error) {
-      console.error("리뷰 id가져오기 실패:", error);
+      console.error("리뷰 id 가져오기 실패:", error);
     }
-  };
+  }, [wineId]); // wineId가 변경될 때만 함수가 다시 생성됨 (usecallback으로 감싸기)
 
   const handleSuccess = (newReviewId: number) => {
     console.log("새로운 리뷰 ID:", newReviewId);
@@ -48,7 +50,7 @@ export default function Page() {
   useEffect(() => {
     if (!wineId) return;
     fetchReviewsId();
-  }, [wineId, reviewsId]);
+  }, [wineId, fetchReviewsId]); //의존성관리를 위한 fetchreviewsid 추가
 
   if (isLoading) {
     return <p>로딩 중...</p>; // 로그인 상태 확인 중일 때 로딩 UI

--- a/src/components/Card/CardDetail.tsx
+++ b/src/components/Card/CardDetail.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { fetchWineById } from "@/lib/api/wine";
 import Image from "next/image";
 
-export default function CardDetail({ id }: { id: string }) {
+export default function CardDetail({ id }: { id: number }) {
   const [wine, setWine] = useState({
     name: "",
     price: 0,

--- a/src/components/Card/CardMyReview/CardMyReview.tsx
+++ b/src/components/Card/CardMyReview/CardMyReview.tsx
@@ -64,9 +64,10 @@ const CardMyReview = ({ review, onDeleteSuccess }: CardMyReviewProps) => {
         </div>
         <MoreMenu
           reviewId={review.id}
-          wineId={review.wine.id}
+          wineId={review.wine?.id}
           userId={review.user.id}
           onDeleteSuccess={onDeleteSuccess}
+          editType="editReview"
         />
       </div>
 

--- a/src/components/Card/CardReview/CardReview.tsx
+++ b/src/components/Card/CardReview/CardReview.tsx
@@ -49,7 +49,11 @@ const ReviewCard = ({ review }: { review: ReviewData }) => {
             initialLiked={review.isLiked}
             userId={review.user.id}
           />
-          <MoreMenu reviewId={review.id} userId={review.user.id} />
+          <MoreMenu
+            reviewId={review.id}
+            userId={review.user.id}
+            editType="editReview"
+          />
         </div>
       </div>
 

--- a/src/components/Card/Mylist/MyList.tsx
+++ b/src/components/Card/Mylist/MyList.tsx
@@ -1,40 +1,42 @@
 "use client";
 import MoreMenu from "@/components/Moremenu/MoreMenu";
 import Image from "next/image";
+import { WineData } from "@/lib/api/wine"; // WineData 가져오기
 
-type WineData = {
-  name: string;
-  price: number;
-  region: string;
-  image: string;
-  reviewId: number;
+// ✅ WineDataWithUserId 타입 정의 (WineData를 확장)
+interface WineDataWithUserId extends WineData {
   userId: number;
-};
+}
 
-export default function MyList({ wine }: { wine: WineData }) {
-  const imageSrc =
-    wine.image && wine.image.startsWith("http")
-      ? wine.image
-      : "/images/wine/wine2.png";
+interface MyListProps {
+  wine: WineDataWithUserId; // WineDataWithUserId 타입 사용
+  onDeleteSuccess?: () => void; // 삭제 후 리스트 업데이트 함수 추가
+}
 
+export default function MyList({ wine, onDeleteSuccess }: MyListProps) {
   return (
     <div className="relative flex flex-wrap items-center max-w-[1140px] w-full h-auto sm:h-[260px] border border-[#CFDBEA] rounded-[16px] shadow-md sm:p-4">
       {/* 와인 이미지 */}
-
       <div className="relative flex-shrink-0 w-[180px] sm:w-[200px] md:w-[220px]">
-        {
-          <Image
-            src={imageSrc}
-            alt="와인 이미지"
-            width={60}
-            height={60}
-            className="object-cover rounded-lg mx-auto"
-          />
-        }
+        <Image
+          src={wine.image}
+          alt={wine.name}
+          width={60}
+          height={60}
+          className="object-cover rounded-lg mx-auto"
+        />
       </div>
+
       <div className="absolute md:top-[30px] md:right-[40px] sm:top-[20px] sm:right-[20px]">
-        <MoreMenu reviewId={wine.reviewId} userId={wine.userId} />
+        <MoreMenu
+          reviewId={wine.id}
+          userId={wine.userId} // userId 유지
+          wineData={wine}
+          editType="editWine"
+          onDeleteSuccess={onDeleteSuccess} // 삭제 후 리스트 갱신 함수 전달
+        />
       </div>
+
       {/* 와인 정보 */}
       <div className="flex flex-col gap-3 sm:gap-5 ml-6">
         <p className="text-xl sm:text-2xl md:text-3xl font-semibold">
@@ -43,8 +45,6 @@ export default function MyList({ wine }: { wine: WineData }) {
         <p className="text-sm sm:text-[14px] md:text-[16px] text-gray-500 font-normal">
           {wine.region}
         </p>
-
-        {/* 가격 태그 */}
         <p
           style={{ backgroundColor: "#F1EDFC", color: "#6A42DB" }}
           className="inline-flex items-center justify-center px-3 sm:px-4 py-1 rounded-[12px] text-[16px] sm:text-[18px] font-bold"

--- a/src/components/Card/ProfileDisplay/ProfileDisplay.tsx
+++ b/src/components/Card/ProfileDisplay/ProfileDisplay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import Image from "next/image";
 
 interface ProfileDisplayProps {
   image?: string;
@@ -54,7 +55,7 @@ const ProfileDisplay: React.FC<ProfileDisplayProps> = ({
 
   return (
     <div className="flex items-center gap-3">
-      <img
+      <Image
         src={profileImage}
         alt="Profile"
         className="w-10 h-10 rounded-full"

--- a/src/components/Card/Wine/WineList.tsx
+++ b/src/components/Card/Wine/WineList.tsx
@@ -76,11 +76,13 @@ export default function WineList() {
 
   // ✅ 와인 추가 (모달에서 등록)
   const handleAddWine = async (wineData: {
+    id?: number;
     name: string;
     region: string;
     image: string;
     price: number;
     type: "RED" | "WHITE" | "SPARKLING";
+    avgRating?: number; // ✅ avgRating을 optional로 정의
   }) => {
     if (!user) {
       alert("로그인이 필요합니다.");
@@ -88,9 +90,12 @@ export default function WineList() {
     }
 
     try {
-      console.log("📤 API 요청 데이터:", wineData);
-      const createdWine = await createWine(wineData);
+      // ✅ 불필요한 id, avgRating 제거 (일단 안쓰고있어서 underscore처리)
+      const { ...validWineData } = wineData;
 
+      // ✅ API 요청 데이터 확인 (id, avgRating 없는지 체크)
+      console.log("📤 API 요청 데이터:", wineData);
+      const createdWine = await createWine(validWineData);
       alert("🍷 새로운 와인이 등록되었습니다.");
       setWines((prevWines) => [
         {

--- a/src/components/Card/Wine/WineList.tsx
+++ b/src/components/Card/Wine/WineList.tsx
@@ -90,8 +90,9 @@ export default function WineList() {
     }
 
     try {
-      // ✅ 불필요한 id, avgRating 제거 (일단 안쓰고있어서 underscore처리)
-      const { ...validWineData } = wineData;
+      // ✅ 불필요한 id, avgRating 제거
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { id, avgRating, ...validWineData } = wineData;
 
       // ✅ API 요청 데이터 확인 (id, avgRating 없는지 체크)
       console.log("📤 API 요청 데이터:", wineData);

--- a/src/components/Modal/ModalReviewAdd/components/ModalReviewForm.tsx
+++ b/src/components/Modal/ModalReviewAdd/components/ModalReviewForm.tsx
@@ -134,7 +134,7 @@ export default function ModalReviewForm({
     if (reviewId && isEditMode) {
       fetchReviewData(reviewId);
     }
-  }, [reviewId, isEditMode]);
+  }, [reviewId, isEditMode, fetchReviewData]); // useEffect 의존성 배열에 fetchReviewData 추가
 
   // ✅ `wineId`가 존재할 경우에만 `fetchWineById` 실행
   useEffect(() => {
@@ -145,7 +145,7 @@ export default function ModalReviewForm({
           return;
         }
         console.log("✅ fetchWineById 실행:", wineId);
-        const response = await fetchWineById(String(wineId));
+        const response = await fetchWineById(wineId);
         setWine({
           id: response.id,
           name: response.name,

--- a/src/components/Modal/ModalWineAdd/ModalWineAdd.tsx
+++ b/src/components/Modal/ModalWineAdd/ModalWineAdd.tsx
@@ -3,20 +3,12 @@
 import { useEffect } from "react";
 import ModalWineAddHeader from "./components/ModalWineAddHeader";
 import ModalWineAddForm from "./components/ModalWineAddForm";
-
-type WineData = {
-  name: string;
-  price: number;
-  region: string;
-  type: "RED" | "WHITE" | "SPARKLING"; // 타입을 string에서 제한된 값으로 수정
-  image: string;
-  avgRating?: number; // avgRating을 optional로 추가
-};
+import { WineData } from "@/lib/api/wine";
 
 type ModalWineAddProps = {
   isOpen: boolean;
   onClose: () => void;
-  wineToEdit?: WineData & { id: number };
+  wineToEdit?: WineData;
   onSubmit: (wineData: WineData) => Promise<void>;
   isEditMode: boolean;
 };
@@ -36,6 +28,7 @@ export default function ModalWineAdd({
     // 수정 모드일 때는 Wine 객체에서 id를 제외한 WineData만 전달
 
     const wineDataToSubmit: WineData = {
+      id: isEditMode ? wineToEdit?.id : 0, // 수정 모드일 때만 id 포함
       name: data.name,
       price: data.price,
       region: data.region,
@@ -77,13 +70,13 @@ export default function ModalWineAdd({
           onSubmit={handleWineSubmit}
           onClose={onClose}
           initialData={{
+            id: wineToEdit?.id ?? 0, // 수정 모드일 때만 전달
             name: wineToEdit?.name ?? "",
             price: wineToEdit?.price ?? 0,
             region: wineToEdit?.region ?? "",
             type: wineToEdit?.type as "RED" | "WHITE" | "SPARKLING",
             image: wineToEdit?.image ?? "",
             avgRating: wineToEdit?.avgRating ?? 0, // 기본값 설정
-            //id: wineToEdit?.id ?? undefined, // id도 기본값을 설정
           }}
           isEditMode={isEditMode}
         />

--- a/src/components/Modal/ModalWineAdd/components/ModalWineAddForm.tsx
+++ b/src/components/Modal/ModalWineAdd/components/ModalWineAddForm.tsx
@@ -4,26 +4,12 @@ import { useEffect, useState } from "react";
 import Button from "@/components/Button/button";
 import { Input, InputFile, InputSelect, Label } from "@/components/Input";
 import { uploadImage } from "@/lib/api/image";
-import { useRouter } from "next/navigation";
+//import { useRouter } from "next/navigation";
+import { WineData } from "@/lib/api/wine";
 
 type ModalWineFormProps = {
-  initialData?: {
-    id?: number;
-    name: string;
-    price: number;
-    region: string;
-    type: "RED" | "WHITE" | "SPARKLING";
-    image: string;
-    avgRating: number;
-  };
-  onSubmit: (data: {
-    name: string;
-    price: number;
-    region: string;
-    type: "RED" | "WHITE" | "SPARKLING"; // 타입을 string에서 제한된 값으로 수정
-    image: string;
-    avgRating: number;
-  }) => Promise<void>;
+  initialData?: WineData; // 중복 타입 선언 제거
+  onSubmit: (data: WineData) => Promise<void>; // 중복 타입 선언 제거
   onClose: () => void;
   isEditMode: boolean;
 };
@@ -44,7 +30,7 @@ export default function ModalWineAddForm({
   // 수정된 부분
   const [formData, setFormData] = useState(initialData);
   const [file, setFile] = useState<File | null>(null);
-  const router = useRouter();
+  //const router = useRouter();
 
   useEffect(() => {
     if (isEditMode && initialData.image) {
@@ -86,20 +72,21 @@ export default function ModalWineAddForm({
     try {
       // POST 요청일 때는 imageUrl 포함해서 보내기
       const wineData = {
-        id: initialData.id, // ✅ 수정 시 ID 포함
+        id: initialData.id, // 수정 시 ID 포함
         name: formData.name,
         price: formData.price || 0,
         region: formData.region,
         type: formData.type,
         image: imageUrl,
-        avgRating: formData.avgRating, // ✅ avgRating 추가
+        avgRating: formData.avgRating, // avgRating 추가
       };
+      console.log("🚀 최종 전송 데이터:", wineData);
 
       // 수정인 경우 PATCH, 새로운 등록일 경우 POST
       await onSubmit(wineData);
 
       // 성공적으로 저장되면 상세 페이지로 리디렉션 (POST 요청이 완료되면 상세 페이지로 이동)
-      router.push("/");
+      //router.push("/");
       onClose();
     } catch (error) {
       console.error("와인 정보 저장 실패", error);

--- a/src/components/Moremenu/MoreMenu.tsx
+++ b/src/components/Moremenu/MoreMenu.tsx
@@ -3,25 +3,33 @@ import Icon from "@/components/Icon/Icon";
 import Dropdown from "@/components/Dropdown";
 import ModalTwoButton from "@/components/Modal/ModalTwoButton/ModalTwoButton";
 import ModalReviewAdd from "@/components/Modal/ModalReviewAdd/ModalReviewAdd";
+import ModalWineAdd from "@/components/Modal/ModalWineAdd/ModalWineAdd";
 import { deleteReview } from "@/lib/api/review";
+import { deleteWine, updateWine, WineData } from "@/lib/api/wine"; // ✅ WineData import
 
 interface MoreMenuProps {
-  reviewId: number; // 리뷰 ID
-  userId: number; // 리뷰 작성자 ID
+  reviewId?: number; // 리뷰 ID (리뷰 수정 전용)
+  userId: number; // 작성자 ID
   wineId?: number;
-  onDeleteSuccess?: () => void; // 삭제 성공 후 UI 업데이트 함수
+  wineData?: WineData; // ✅ wineData에서 wineId 가져옴
+  editType: "editReview" | "editWine"; // ✅ 수정 유형
+  onDeleteSuccess?: () => void;
 }
 
 const MoreMenu: React.FC<MoreMenuProps> = ({
   reviewId,
   userId,
-  wineId,
+  wineData, // ✅ wineData에서 wineId 추출
+  editType,
   onDeleteSuccess,
 }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [loggedInUserId, setLoggedInUserId] = useState<number | null>(null);
+
+  // ✅ wineData에서 id 추출 (wineId 직접 받는 방식 제거)
+  const wineId = wineData?.id;
 
   useEffect(() => {
     const storedUserId = localStorage.getItem("user_id");
@@ -32,20 +40,58 @@ const MoreMenu: React.FC<MoreMenuProps> = ({
 
   const isOwner = loggedInUserId === userId; // ✅ 본인 리뷰인지 확인
 
-  const handleDeleteReview = async () => {
+  const handleDelete = async () => {
+    if (editType === "editWine" && !wineId) {
+      console.error("❌ wineId가 없습니다. 삭제할 수 없습니다.");
+      return;
+    }
+
     try {
-      await deleteReview(reviewId);
+      if (editType === "editReview" && reviewId) {
+        await deleteReview(reviewId);
+      } else if (editType === "editWine" && wineId) {
+        await deleteWine(wineId);
+      }
+
+      console.log("✅ 삭제 완료");
       setIsDeleteModalOpen(false);
+
       if (onDeleteSuccess) {
+        console.log("✅ 삭제 후 리스트 갱신 실행");
         onDeleteSuccess();
       }
     } catch (error) {
-      console.error("리뷰 삭제 실패:", error);
+      console.error("❌ 삭제 실패:", error);
     }
   };
+
+  const handleWineUpdate = async (updatedWine: WineData) => {
+    try {
+      console.log("🚀 수정 요청 데이터(전송 전):", updatedWine);
+
+      if (!updatedWine.id) {
+        console.error("❌ 와인 ID가 없습니다. 업데이트를 진행할 수 없습니다.");
+        return;
+      }
+
+      // API 요청 본문에서 `id` 필드 제거
+      const { id, ...wineDataWithoutId } = updatedWine;
+
+      await updateWine(id, wineDataWithoutId); // ✅ id는 URL에 포함하고, 본문에서는 제거
+      alert("✅ 와인 정보가 수정되었습니다.");
+
+      setIsEditModalOpen(false);
+      if (onDeleteSuccess) {
+        onDeleteSuccess(); // ✅ `fetchMyWines()` 실행
+      }
+    } catch (error) {
+      console.error("❌ 와인 수정 실패:", error);
+    }
+  };
+
   return (
     <div className="relative">
-      {/* ✅ 모든 리뷰에서 햄버거 메뉴(⋮) 보이게 수정 */}
+      {/* 모든 리뷰에서 햄버거 메뉴(⋮) 보이게 수정 */}
       <Dropdown
         trigger={
           <button onClick={() => setIsDropdownOpen(!isDropdownOpen)}>
@@ -62,7 +108,7 @@ const MoreMenu: React.FC<MoreMenuProps> = ({
           { label: "삭제하기", value: "delete" },
         ]}
         onSelect={(value) => {
-          // ✅ 본인이 아니면 동작하지 않도록 설정
+          // 본인이 아니면 동작하지 않도록 설정
           if (!isOwner) {
             alert("본인만 수정/삭제할 수 있습니다.");
             return;
@@ -79,12 +125,23 @@ const MoreMenu: React.FC<MoreMenuProps> = ({
       />
 
       {/* 리뷰 수정 모달 */}
-      {isEditModalOpen && (
+      {isEditModalOpen && editType === "editReview" && reviewId && (
         <ModalReviewAdd
           isOpen={isEditModalOpen}
           onClose={() => setIsEditModalOpen(false)}
           wineId={wineId}
           initialReviewId={reviewId} // 기존 리뷰 ID 전달 → 수정 모드로 동작
+        />
+      )}
+
+      {/* ✅ 와인 수정 모달 */}
+      {isEditModalOpen && editType === "editWine" && wineData && (
+        <ModalWineAdd
+          isOpen={isEditModalOpen}
+          onClose={() => setIsEditModalOpen(false)}
+          wineToEdit={wineData} // wineData 전달
+          isEditMode={true}
+          onSubmit={handleWineUpdate}
         />
       )}
 
@@ -94,7 +151,7 @@ const MoreMenu: React.FC<MoreMenuProps> = ({
           size="md"
           isOpen={isDeleteModalOpen}
           setIsOpen={setIsDeleteModalOpen}
-          onConfirm={handleDeleteReview}
+          onConfirm={handleDelete}
         />
       )}
     </div>

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -44,10 +44,10 @@ export const fetchMyReviews = async (limit: number, cursor?: number | null) => {
 };
 
 // ✅ 내가 만든 와인 목록 조회
-export const fetchMyWines = async (limit: number, cursor?: string) => {
+export const fetchMyWines = async (limit: number, cursor?: number) => {
   try {
-    const params: { limit: number; cursor?: string } = { limit };
-    if (cursor) params.cursor = cursor; // cursor 값이 있을 때만 추가
+    const params: { limit: number; cursor?: number } = { limit };
+    if (cursor !== null) params.cursor = cursor; // cursor 값이 있을 때만 추가
 
     const response = await apiClient.get("/users/me/wines", { params });
     return response.data;

--- a/src/lib/api/wine.ts
+++ b/src/lib/api/wine.ts
@@ -1,13 +1,14 @@
 import apiClient from "./api";
 
-interface WineData {
+export type WineData = {
+  id?: number;
   name: string;
-  type: "RED" | "WHITE" | "SPARKLING"; // 와인 종류
+  region: string;
+  image: string; // 선택적 이미지 URL
   price: number;
-  rating?: number; // 선택적 평점
-  description?: string; // 선택적 설명
-  imageUrl?: string; // 선택적 이미지 URL
-}
+  avgRating?: number; // 선택적 평점
+  type: "RED" | "WHITE" | "SPARKLING"; // 와인 종류
+};
 
 // ✅ 와인 생성
 export const createWine = async (wineData: WineData) => {
@@ -53,7 +54,7 @@ export const fetchRecommendedWines = async (limit: number) => {
 };
 
 // ✅ 와인 상세 조회
-export const fetchWineById = async (wineId: string) => {
+export const fetchWineById = async (wineId: number) => {
   try {
     const response = await apiClient.get(`/wines/${wineId}`);
     return response.data;
@@ -64,7 +65,7 @@ export const fetchWineById = async (wineId: string) => {
 };
 
 // ✅ 와인 수정
-export const updateWine = async (wineId: string, wineData: WineData) => {
+export const updateWine = async (wineId: number, wineData: WineData) => {
   try {
     const response = await apiClient.patch(`/wines/${wineId}`, wineData);
     return response.data;
@@ -75,7 +76,7 @@ export const updateWine = async (wineId: string, wineData: WineData) => {
 };
 
 // ✅ 와인 삭제
-export const deleteWine = async (wineId: string) => {
+export const deleteWine = async (wineId: number) => {
   try {
     const response = await apiClient.delete(`/wines/${wineId}`);
     return response.data;


### PR DESCRIPTION
## #️⃣ 이슈

- close #129 

## 📝 작업 내용

- 마이프로필페이지 -내가 등록한 와인  mylist 연결하여 수정/삭제 기능 구현
- 리뷰/와인 총 갯수 컴포넌트 수정 및  구현
- 수정/삭제 시 리뷰목록 새로고침없이 재렌더링 추가
- modalwineadd 컴포넌트에서 수정 시 홈으로 이동하는걸 우선 주석처리하여 막아놨습니다.
- 빌드 시 타입에러 및 와인리스트 무한렌더링 문제 수정 및 각종 타입에러 및 기능에러 수정

## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
다른분들이 작업한 코드도 엄청 수정을했습니다 구조를 바꾸기보단 타입정리 또는 에러를 수정하고 
와인등록모달 관련 컴포넌트는 수정/삭제 기능을 위해 prop 넘기기, 리뷰/와인 수정 을 edittype으로 정리하여 분리하는 로직을 추가했습니다. 확인 후 에러 확인된다면 공유하여 수정이 필요할수도있습니다.